### PR TITLE
Disable HTTP connection pooling in default client

### DIFF
--- a/codex-rs/core/src/default_client.rs
+++ b/codex-rs/core/src/default_client.rs
@@ -28,6 +28,7 @@ pub fn create_client(originator: &str) -> reqwest::Client {
         // Set UA via dedicated helper to avoid header validation pitfalls
         .user_agent(ua)
         .default_headers(headers)
+        .pool_max_idle_per_host(0)
         .build()
     {
         Ok(client) => client,


### PR DESCRIPTION
## Summary
- disable reqwest's connection pooling to ensure separate API connections and avoid pooling loop when Codex exec is invoked from Codex

## Testing
- `cargo clippy -p codex-core`
- `cargo test -p codex-core` *(fails: called `Result::unwrap()` on an `Err` value: NotPresent)*
- `cargo test --all-features` *(fails: called `Result::unwrap()` on an `Err` value: NotPresent)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8eeb3d288328b87c4dc06ae1e1d5