### PR TITLE
Allow TUI config to ignore unknown fields

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1216,6 +1216,17 @@ persistence = "none"
     }
 
     #[test]
+    fn tui_config_with_unrecognized_fields_is_ignored() {
+        let cfg = r#"tui = { theme = { name = "dark-charcoal-rainbow" } }"#;
+
+        let parsed = toml::from_str::<ConfigToml>(cfg)
+            .expect("TUI config with unrecognized fields should succeed");
+        let tui = parsed.tui.expect("config should include tui section");
+
+        assert_eq!(tui.notifications, Notifications::Enabled(false));
+    }
+
+    #[test]
     fn test_sandbox_config_parsing() {
         let sandbox_full_access = r#"
 sandbox_mode = "danger-full-access"


### PR DESCRIPTION
## Summary
- ignore unrecognized fields when deserializing the TUI config so partial settings still load
- add a regression test that allows inline TUI tables without notifications

## Testing
✅ USER=codex USERNAME=codex cargo test -p codex-core

------
https://chatgpt.com/codex/tasks/task_e_68cc8a358074832883e2f4aadf1fbea7