### PR TITLE
Make file search case insensitive

### DIFF
--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -363,7 +363,7 @@ fn create_worker_count(num_workers: NonZero<usize>) -> WorkerCount {
 fn create_pattern(pattern: &str) -> Pattern {
     Pattern::new(
         pattern,
-        CaseMatching::Smart,
+        CaseMatching::Ignore,
         Normalization::Smart,
         AtomKind::Fuzzy,
     )
@@ -402,5 +402,35 @@ mod tests {
         ];
 
         assert_eq!(matches, expected);
+    }
+
+    #[test]
+    fn lowercase_query_matches_uppercase_filename() {
+        let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
+        let mut utf32buf = Vec::<char>::new();
+        let haystack: Utf32Str<'_> = Utf32Str::new("TODOS.md", &mut utf32buf);
+        let pattern = create_pattern("tod");
+
+        let score = pattern.score(haystack, &mut matcher);
+
+        assert!(
+            score.is_some(),
+            "expected lowercase query to match uppercase filename"
+        );
+    }
+
+    #[test]
+    fn lowercase_query_matches_uppercase_segment_in_path() {
+        let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
+        let mut utf32buf = Vec::<char>::new();
+        let haystack: Utf32Str<'_> = Utf32Str::new("docs/TODOS.md", &mut utf32buf);
+        let pattern = create_pattern("tod");
+
+        let score = pattern.score(haystack, &mut matcher);
+
+        assert!(
+            score.is_some(),
+            "expected lowercase query to match uppercase segment within a path"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- change the file-search pattern builder to always ignore case so lowercase queries can match uppercase filenames
- add regression tests that cover matching uppercase filenames and path segments from lowercase queries

## Testing
- `cargo test -p codex-file-search`
- `USER=ci USERNAME=ci cargo test -p codex-core`


------
https://chatgpt.com/codex/tasks/task_e_68cc91552b788328824cc51bc9ac34a2